### PR TITLE
Update entropy variable name

### DIFF
--- a/draft-ohai-chunked-ohttp.md
+++ b/draft-ohai-chunked-ohttp.md
@@ -233,16 +233,16 @@ For responses, the first piece of data sent back is the response nonce,
 as in the non-chunked variant.
 
 ~~~
-entropy = max(Nn, Nk)
-response_nonce = random(entropy)
+entropy_len = max(Nn, Nk)
+response_nonce = random(entropy_len)
 ~~~
 
 Each chunk is sealed using the same AEAD key and AEAD nonce that are
 derived for the non-chunked variant, which are calculated as follows:
 
 ~~~
-secret = context.Export("message/bhttp chunked response", entropy)
-response_nonce = random(entropy)
+secret = context.Export("message/bhttp chunked response", entropy_len)
+response_nonce = random(entropy_len)
 salt = concat(enc, response_nonce)
 prk = Extract(salt, secret)
 aead_key = Expand(prk, "key", Nk)


### PR DESCRIPTION
`entropy` alone seems like it names a buffer, rather than an integer length.